### PR TITLE
Bumping down requests version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='ben@codekitchen.io',
     packages=find_packages(exclude=['test_*.py']),
     install_requires=[
-        'requests>=2.22.0',
+        'requests>=2.20.0',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
To help resolve the `requests` library conflicts in `nj-cms`, we can at least make this chargify repo use a lower required version of `requests` (assuming that everything still works).

Testing done:
I've tested the nj-cms api endpoints locally, which proved to work. I'm confident that the decreasing of version number should be okay.

Testing
You can install from a branch with the line 
```git+https://github.com/NationalJournal/chargify-python.git@bump-down-requests```
in your requirements.txt. You'll have to reinstall from requirements.txt to make sure it works. 

Probably best to do a quick run through of testing the some of the chargify api endpoints via the vignette user management system. 